### PR TITLE
Fix visual bug with smooth font

### DIFF
--- a/plugins/default/font/components/TextRenderer.ts
+++ b/plugins/default/font/components/TextRenderer.ts
@@ -47,7 +47,12 @@ export default class TextRenderer extends SupEngine.ActorComponent {
         mesh.material.transparent = true;
         mesh.material.opacity = this.opacity;
       } else {
-        mesh.material.transparent = false;
+        if (this.font.filtering === "smooth") {
+					mesh.material.transparent = true;
+				}
+				else {
+					mesh.material.transparent = false;
+				}
         mesh.material.opacity = 1;
       }
     }

--- a/plugins/default/font/components/TextRenderer.ts
+++ b/plugins/default/font/components/TextRenderer.ts
@@ -48,11 +48,11 @@ export default class TextRenderer extends SupEngine.ActorComponent {
         mesh.material.opacity = this.opacity;
       } else {
         if (this.font.filtering === "smooth") {
-					mesh.material.transparent = true;
-				}
-				else {
-					mesh.material.transparent = false;
-				}
+	  mesh.material.transparent = true;
+        }
+        else {
+          mesh.material.transparent = false;
+        }
         mesh.material.opacity = 1;
       }
     }


### PR DESCRIPTION
Smooth font need to have a transparent material because the border has a pixel alpha channel under 1.0