### PR TITLE
eventEmitter: Update definitions for node.js v4.2.4

### DIFF
--- a/plugins/extra/eventEmitter/typescriptAPI/EventEmitter.d.ts.txt
+++ b/plugins/extra/eventEmitter/typescriptAPI/EventEmitter.d.ts.txt
@@ -1,12 +1,19 @@
+// Definitions for node.js v4.2.4
 declare class EventEmitter {
-  static listenerCount(emitter: EventEmitter, event: string): number;
-
-  addListener(event: string, listener: Function): EventEmitter;
   on(event: string, listener: Function): EventEmitter;
+  addListener(event: string, listener: Function): EventEmitter;
   once(event: string, listener: Function): EventEmitter;
+  
   removeListener(event: string, listener: Function): EventEmitter;
   removeAllListeners(event?: string): EventEmitter;
-  setMaxListeners(n: number): void;
-  listeners(event: string): Function[];
+  
   emit(event: string, ...args: any[]): boolean;
+
+  static defaultMaxListeners: number;
+  setMaxListeners(n: number): EventEmitter;
+  getMaxListener(): number
+
+  listeners(event: string): Function[];
+  listenerCount(event: string): number;  
+  static listenerCount(emitter: EventEmitter, event: string): number; // deprecated
 }


### PR DESCRIPTION
- static listenerCount() is now deprecated
- added listenerCount()
- added getMaxListener()
- added static defaultMaxListeners property
- fixed return type of setMaxListener()