### PR TITLE
Improved CannonBody Component Editor

### DIFF
--- a/plugins/extra/cannonjs/componentConfigs/CannonBodyConfig.ts
+++ b/plugins/extra/cannonjs/componentConfigs/CannonBodyConfig.ts
@@ -7,7 +7,7 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
 
     shape: { type: "enum", items: ["box", "sphere", "cylinder"], mutable: true },
 
-    offset: {
+    positionOffset: {
       mutable: true,
       type: "hash",
       properties: {
@@ -16,7 +16,7 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
         z: { type: "number", mutable: true },
       }
     },
-    orientation: {
+    orientationOffset: {
         mutable: true,
         type: "hash",
         properties: {
@@ -44,9 +44,9 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
     return {
       mass: 0,
       fixedRotation: false,
-      offset: { x: 0, y: 0, z: 0 },
       shape: "box",
-      orientation: { x: 0, y: 0, z: 0 },
+      positionOffset: { x: 0, y: 0, z: 0 },
+      orientationOffset: { x: 0, y: 0, z: 0 },
       halfSize: { x: 0.5, y: 0.5, z: 0.5 },
       radius: 1,
       height: 1,
@@ -61,24 +61,21 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
 
     // NOTE: offset was introduced in Superpowers 0.14
     // to merge offsetX, offsetY and offsetZ
-    if (pub.offsetX != null) {
-      pub.offset = {
+    if (pub.offset != null) {
+        pub.positionOffset = pub.offset;
+    } else if (pub.offsetX != null) {
+      pub.positionOffset = {
         x: pub.offsetX,
         y: pub.offsetY,
         z: pub.offsetZ,
       };
-
       delete pub.offsetX;
       delete pub.offsetY;
       delete pub.offsetZ;
     }
 
-    if( pub.orientation == null ){
-        pub.orientation = {
-            x: 0,
-            y: 0,
-            z: 0
-        };
+    if( pub.orientationOffset == null ){
+        pub.orientationOffset = { x: 0, y: 0, z: 0 };
     }
 
     // NOTE: halfSize was introduced in Superpowers 0.14
@@ -89,7 +86,6 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
         y: pub.halfHeight,
         z: pub.halfDepth
       };
-
       delete pub.halfWidth;
       delete pub.halfHeight;
       delete pub.halfDepth;

--- a/plugins/extra/cannonjs/componentConfigs/CannonBodyConfig.ts
+++ b/plugins/extra/cannonjs/componentConfigs/CannonBodyConfig.ts
@@ -2,6 +2,11 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
   static schema: SupCore.Data.Schema = {
     mass: { type: "number", min: 0, mutable: true },
     fixedRotation: { type: "boolean", mutable: true },
+    group: { type: "number", mutable: true },
+    mask: { type: "number", mutable: true },
+
+    shape: { type: "enum", items: ["box", "sphere", "cylinder"], mutable: true },
+
     offset: {
       mutable: true,
       type: "hash",
@@ -11,9 +16,6 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
         z: { type: "number", mutable: true },
       }
     },
-
-    shape: { type: "enum", items: ["box", "sphere", "cylinder"], mutable: true },
-
     orientation: {
         mutable: true,
         type: "hash",
@@ -33,7 +35,6 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
         z: { type: "number", min: 0, mutable: true },
       }
     },
-
     radius: { type: "number", min: 0, mutable: true },
     height: { type: "number", min: 0, mutable: true },
     segments: { type: "number", min: 3, mutable: true }
@@ -54,6 +55,10 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
   }
 
   constructor(pub: any) {
+
+    if (pub.group == null) pub.group = 1;
+    if (pub.mask == null) pub.mask = 1;
+
     // NOTE: offset was introduced in Superpowers 0.14
     // to merge offsetX, offsetY and offsetZ
     if (pub.offsetX != null) {

--- a/plugins/extra/cannonjs/componentConfigs/CannonBodyConfig.ts
+++ b/plugins/extra/cannonjs/componentConfigs/CannonBodyConfig.ts
@@ -14,6 +14,16 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
 
     shape: { type: "enum", items: ["box", "sphere", "cylinder"], mutable: true },
 
+    orientation: {
+        mutable: true,
+        type: "hash",
+        properties: {
+            x: { type: "number", mutable: true },
+            y: { type: "number", mutable: true },
+            z: { type: "number", mutable: true }
+        }
+    },
+
     halfSize: {
       mutable: true,
       type: "hash",
@@ -25,7 +35,8 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
     },
 
     radius: { type: "number", min: 0, mutable: true },
-    height: { type: "number", min: 0, mutable: true }
+    height: { type: "number", min: 0, mutable: true },
+    segments: { type: "number", min: 3, mutable: true }
   };
 
   static create() {
@@ -34,9 +45,11 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
       fixedRotation: false,
       offset: { x: 0, y: 0, z: 0 },
       shape: "box",
+      orientation: { x: 0, y: 0, z: 0 },
       halfSize: { x: 0.5, y: 0.5, z: 0.5 },
       radius: 1,
-      height: 1
+      height: 1,
+      segments: 16
     };
   }
 
@@ -53,6 +66,14 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
       delete pub.offsetX;
       delete pub.offsetY;
       delete pub.offsetZ;
+    }
+
+    if( pub.orientation == null ){
+        pub.orientation = {
+            x: 0,
+            y: 0,
+            z: 0
+        };
     }
 
     // NOTE: halfSize was introduced in Superpowers 0.14
@@ -72,6 +93,7 @@ export default class CannonBodyConfig extends SupCore.Data.Base.ComponentConfig 
     if (pub.shape == null) pub.shape = "box";
     if (pub.radius == null) pub.radius = 1;
     if (pub.height == null) pub.height  = 1;
+    if (pub.segments == null) pub.segments = 16;
 
     super(pub, CannonBodyConfig.schema);
   }

--- a/plugins/extra/cannonjs/componentEditors/CannonBodyEditor.ts
+++ b/plugins/extra/cannonjs/componentEditors/CannonBodyEditor.ts
@@ -4,9 +4,11 @@ export default class CannonBodyEditor {
   fields: { [name: string]: HTMLInputElement|HTMLSelectElement };
   projectClient: SupClient.ProjectClient;
   editConfig: any;
+  orientationRow: SupClient.table.RowParts;
   halfSizeRow: SupClient.table.RowParts;
   radiusRow: SupClient.table.RowParts;
   heightRow: SupClient.table.RowParts;
+  segmentsRow: SupClient.table.RowParts;
 
   constructor(tbody: HTMLTableSectionElement, config: any, projectClient: SupClient.ProjectClient, editConfig: any) {
     this.projectClient = projectClient;
@@ -26,25 +28,6 @@ export default class CannonBodyEditor {
       this.editConfig("setProperty", "fixedRotation", (<HTMLInputElement>event.target).checked);
     });
 
-    let offsetRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.offset"));
-    let offsetFields = SupClient.table.appendNumberFields(offsetRow.valueCell, [ config.offset.x, config.offset.y, config.offset.z ]);
-    this.fields["offset.x"] = offsetFields[0];
-    this.fields["offset.y"] = offsetFields[1];
-    this.fields["offset.z"] = offsetFields[2];
-
-    this.fields["offset.x"].addEventListener("change", (event) => {
-      this.editConfig("setProperty", "offset.x", parseFloat((<HTMLInputElement>event.target).value));
-    });
-
-    this.fields["offset.y"].addEventListener(
-      "change", (event) => {
-        this.editConfig("setProperty", "offset.y", parseFloat((<HTMLInputElement>event.target).value));
-      });
-
-    this.fields["offset.z"].addEventListener("change", (event) => {
-      this.editConfig("setProperty", "offset.z", parseFloat((<HTMLInputElement>event.target).value));
-    });
-
     SupClient.table.appendHeader(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.shape"));
     let shapeTypeRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.shapeType"));
     this.fields["shape"] = SupClient.table.appendSelectBox(shapeTypeRow.valueCell, {
@@ -57,22 +40,48 @@ export default class CannonBodyEditor {
       this.editConfig("setProperty", "shape", (<HTMLInputElement>event.target).value);
     });
 
+    let offsetRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.offset"));
+    let offsetFields = SupClient.table.appendNumberFields(offsetRow.valueCell, [ config.offset.x, config.offset.y, config.offset.z ]);
+    this.fields["offset.x"] = offsetFields[0];
+    this.fields["offset.y"] = offsetFields[1];
+    this.fields["offset.z"] = offsetFields[2];
+    this.fields["offset.x"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "offset.x", parseFloat((<HTMLInputElement>event.target).value));
+    });
+    this.fields["offset.y"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "offset.y", parseFloat((<HTMLInputElement>event.target).value));
+    });
+    this.fields["offset.z"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "offset.z", parseFloat((<HTMLInputElement>event.target).value));
+    });
+
+    this.orientationRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.orientation"));
+    let orientationFields = SupClient.table.appendNumberFields(this.orientationRow.valueCell, [ config.orientation.x, config.orientation.y, config.orientation.z ], { min: -360, max: 360 });
+    this.fields["orientation.x"] = orientationFields[0];
+    this.fields["orientation.y"] = orientationFields[1];
+    this.fields["orientation.z"] = orientationFields[2];
+    this.fields["orientation.x"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "orientation.x", parseFloat((<HTMLInputElement>event.target).value));
+    });
+    this.fields["orientation.y"].addEventListener("change", (event) => {
+      this.editConfig("setProperty", "orientation.y", parseFloat((<HTMLInputElement>event.target).value));
+    });
+    this.fields["orientation.z"].addEventListener("change", (event) => {
+      this.editConfig("setProperty", "orientation.z", parseFloat((<HTMLInputElement>event.target).value));
+    });
+
     // Box
     this.halfSizeRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.halfSize"));
     let halfSizeFields = SupClient.table.appendNumberFields(this.halfSizeRow.valueCell, [ config.halfSize.x, config.halfSize.y, config.halfSize.z ], { min: 0 });
     this.fields["halfSize.x"] = halfSizeFields[0];
     this.fields["halfSize.y"] = halfSizeFields[1];
     this.fields["halfSize.z"] = halfSizeFields[2];
-
-    this.fields["halfSize.x"].addEventListener(
-      "change", (event) => {
+    this.fields["halfSize.x"].addEventListener("change", (event) => {
         this.editConfig("setProperty", "halfSize.x", parseFloat((<HTMLInputElement>event.target).value));
-      });
-
+    });
     this.fields["halfSize.y"].addEventListener("change", (event) => {
       this.editConfig("setProperty", "halfSize.y", parseFloat((<HTMLInputElement>event.target).value));
     });
-
     this.fields["halfSize.z"].addEventListener("change", (event) => {
       this.editConfig("setProperty", "halfSize.z", parseFloat((<HTMLInputElement>event.target).value));
     });
@@ -90,25 +99,37 @@ export default class CannonBodyEditor {
       this.editConfig("setProperty", "height", parseFloat((<HTMLInputElement>event.target).value));
     });
 
+    this.segmentsRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.segments"));
+    this.fields["segments"] = SupClient.table.appendNumberField(this.segmentsRow.valueCell, config.segments, { min: 3 });
+    this.fields["segments"].addEventListener("change", (event) => {
+      this.editConfig("setProperty", "segments", parseInt((<HTMLInputElement>event.target).value));
+    });
+
     this.updateShapeInput(config.shape);
   }
 
   updateShapeInput(shape: string) {
     switch (shape) {
       case "box":
+        this.orientationRow.row.hidden = false;
         this.halfSizeRow.row.hidden = false;
         this.radiusRow.row.hidden = true;
         this.heightRow.row.hidden = true;
+        this.segmentsRow.row.hidden = true;
         break;
       case "sphere":
+        this.orientationRow.row.hidden = true;
         this.halfSizeRow.row.hidden = true;
         this.radiusRow.row.hidden = false;
         this.heightRow.row.hidden = true;
+        this.segmentsRow.row.hidden = true;
         break;
       case "cylinder":
+        this.orientationRow.row.hidden = false;
         this.halfSizeRow.row.hidden = true;
         this.radiusRow.row.hidden = false;
         this.heightRow.row.hidden = false;
+        this.segmentsRow.row.hidden = false;
         break;
     }
   }

--- a/plugins/extra/cannonjs/componentEditors/CannonBodyEditor.ts
+++ b/plugins/extra/cannonjs/componentEditors/CannonBodyEditor.ts
@@ -15,20 +15,31 @@ export default class CannonBodyEditor {
     this.editConfig = editConfig;
     this.tbody = tbody;
     this.fields = {};
+
     let massRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.mass"));
     this.fields["mass"] = SupClient.table.appendNumberField(massRow.valueCell, config.mass, { min: 0 });
-    this.fields["mass"].addEventListener(
-      "change", (event) => {
+    this.fields["mass"].addEventListener("change", (event) => {
         this.editConfig("setProperty", "mass", parseFloat((<HTMLInputElement>event.target).value));
-      });
-
+    });
     let fixedRotationRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.fixedRotation"));
     this.fields["fixedRotation"] = SupClient.table.appendBooleanField(fixedRotationRow.valueCell, config.fixedRotation);
     this.fields["fixedRotation"].addEventListener("click", (event) => {
-      this.editConfig("setProperty", "fixedRotation", (<HTMLInputElement>event.target).checked);
+        this.editConfig("setProperty", "fixedRotation", (<HTMLInputElement>event.target).checked);
+    });
+    let groupRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.group"));
+    this.fields["group"] = SupClient.table.appendNumberField(groupRow.valueCell, config.group);
+    this.fields["group"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "group", parseInt((<HTMLInputElement>event.target).value));
+    });
+    let maskRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.mask"));
+    this.fields["mask"] = SupClient.table.appendNumberField(maskRow.valueCell, config.mask);
+    this.fields["mask"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "mask", parseInt((<HTMLInputElement>event.target).value));
     });
 
+    // display a gray bar with "shape" written in it
     SupClient.table.appendHeader(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.shape"));
+
     let shapeTypeRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.shapeType"));
     this.fields["shape"] = SupClient.table.appendSelectBox(shapeTypeRow.valueCell, {
       "box": SupClient.i18n.t("componentEditors:CannonBody.shapeOptions.box"),
@@ -55,6 +66,7 @@ export default class CannonBodyEditor {
         this.editConfig("setProperty", "offset.z", parseFloat((<HTMLInputElement>event.target).value));
     });
 
+    // Box / Cylinder
     this.orientationRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.orientation"));
     let orientationFields = SupClient.table.appendNumberFields(this.orientationRow.valueCell, [ config.orientation.x, config.orientation.y, config.orientation.z ], { min: -360, max: 360 });
     this.fields["orientation.x"] = orientationFields[0];
@@ -93,12 +105,12 @@ export default class CannonBodyEditor {
       this.editConfig("setProperty", "radius", parseFloat((<HTMLInputElement>event.target).value));
     });
 
+    // Cylinder
     this.heightRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.height"));
     this.fields["height"] = SupClient.table.appendNumberField(this.heightRow.valueCell, config.height, { min: 0 });
     this.fields["height"].addEventListener("change", (event) => {
       this.editConfig("setProperty", "height", parseFloat((<HTMLInputElement>event.target).value));
     });
-
     this.segmentsRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.segments"));
     this.fields["segments"] = SupClient.table.appendNumberField(this.segmentsRow.valueCell, config.segments, { min: 3 });
     this.fields["segments"].addEventListener("change", (event) => {

--- a/plugins/extra/cannonjs/componentEditors/CannonBodyEditor.ts
+++ b/plugins/extra/cannonjs/componentEditors/CannonBodyEditor.ts
@@ -4,7 +4,7 @@ export default class CannonBodyEditor {
   fields: { [name: string]: HTMLInputElement|HTMLSelectElement };
   projectClient: SupClient.ProjectClient;
   editConfig: any;
-  orientationRow: SupClient.table.RowParts;
+  orientationOffsetRow: SupClient.table.RowParts;
   halfSizeRow: SupClient.table.RowParts;
   radiusRow: SupClient.table.RowParts;
   heightRow: SupClient.table.RowParts;
@@ -51,35 +51,37 @@ export default class CannonBodyEditor {
       this.editConfig("setProperty", "shape", (<HTMLInputElement>event.target).value);
     });
 
-    let offsetRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.offset"));
-    let offsetFields = SupClient.table.appendNumberFields(offsetRow.valueCell, [ config.offset.x, config.offset.y, config.offset.z ]);
-    this.fields["offset.x"] = offsetFields[0];
-    this.fields["offset.y"] = offsetFields[1];
-    this.fields["offset.z"] = offsetFields[2];
-    this.fields["offset.x"].addEventListener("change", (event) => {
-        this.editConfig("setProperty", "offset.x", parseFloat((<HTMLInputElement>event.target).value));
+    let positionOffsetRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.positionOffset"));
+    let positionOffsetFields = SupClient.table.appendNumberFields(positionOffsetRow.valueCell, [ config.positionOffset.x, config.positionOffset.y, config.positionOffset.z ]);
+    this.fields["positionOffset.x"] = positionOffsetFields[0];
+    this.fields["positionOffset.y"] = positionOffsetFields[1];
+    this.fields["positionOffset.z"] = positionOffsetFields[2];
+
+    this.fields["positionOffset.x"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "positionOffset.x", parseFloat((<HTMLInputElement>event.target).value));
     });
-    this.fields["offset.y"].addEventListener("change", (event) => {
-        this.editConfig("setProperty", "offset.y", parseFloat((<HTMLInputElement>event.target).value));
+    this.fields["positionOffset.y"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "positionOffset.y", parseFloat((<HTMLInputElement>event.target).value));
     });
-    this.fields["offset.z"].addEventListener("change", (event) => {
-        this.editConfig("setProperty", "offset.z", parseFloat((<HTMLInputElement>event.target).value));
+    this.fields["positionOffset.z"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "positionOffset.z", parseFloat((<HTMLInputElement>event.target).value));
     });
 
     // Box / Cylinder
-    this.orientationRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.orientation"));
-    let orientationFields = SupClient.table.appendNumberFields(this.orientationRow.valueCell, [ config.orientation.x, config.orientation.y, config.orientation.z ], { min: -360, max: 360 });
-    this.fields["orientation.x"] = orientationFields[0];
-    this.fields["orientation.y"] = orientationFields[1];
-    this.fields["orientation.z"] = orientationFields[2];
-    this.fields["orientation.x"].addEventListener("change", (event) => {
-        this.editConfig("setProperty", "orientation.x", parseFloat((<HTMLInputElement>event.target).value));
+    this.orientationOffsetRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:CannonBody.orientationOffset"));
+    let orientationOffsetFields = SupClient.table.appendNumberFields(this.orientationOffsetRow.valueCell, [ config.orientationOffset.x, config.orientationOffset.y, config.orientationOffset.z ], { min: -360, max: 360 });
+    this.fields["orientationOffset.x"] = orientationOffsetFields[0];
+    this.fields["orientationOffset.y"] = orientationOffsetFields[1];
+    this.fields["orientationOffset.z"] = orientationOffsetFields[2];
+
+    this.fields["orientationOffset.x"].addEventListener("change", (event) => {
+        this.editConfig("setProperty", "orientationOffset.x", parseFloat((<HTMLInputElement>event.target).value));
     });
-    this.fields["orientation.y"].addEventListener("change", (event) => {
-      this.editConfig("setProperty", "orientation.y", parseFloat((<HTMLInputElement>event.target).value));
+    this.fields["orientationOffset.y"].addEventListener("change", (event) => {
+      this.editConfig("setProperty", "orientationOffset.y", parseFloat((<HTMLInputElement>event.target).value));
     });
-    this.fields["orientation.z"].addEventListener("change", (event) => {
-      this.editConfig("setProperty", "orientation.z", parseFloat((<HTMLInputElement>event.target).value));
+    this.fields["orientationOffset.z"].addEventListener("change", (event) => {
+      this.editConfig("setProperty", "orientationOffset.z", parseFloat((<HTMLInputElement>event.target).value));
     });
 
     // Box
@@ -123,21 +125,21 @@ export default class CannonBodyEditor {
   updateShapeInput(shape: string) {
     switch (shape) {
       case "box":
-        this.orientationRow.row.hidden = false;
+        this.orientationOffsetRow.row.hidden = false;
         this.halfSizeRow.row.hidden = false;
         this.radiusRow.row.hidden = true;
         this.heightRow.row.hidden = true;
         this.segmentsRow.row.hidden = true;
         break;
       case "sphere":
-        this.orientationRow.row.hidden = true;
+        this.orientationOffsetRow.row.hidden = true;
         this.halfSizeRow.row.hidden = true;
         this.radiusRow.row.hidden = false;
         this.heightRow.row.hidden = true;
         this.segmentsRow.row.hidden = true;
         break;
       case "cylinder":
-        this.orientationRow.row.hidden = false;
+        this.orientationOffsetRow.row.hidden = false;
         this.halfSizeRow.row.hidden = true;
         this.radiusRow.row.hidden = false;
         this.heightRow.row.hidden = false;

--- a/plugins/extra/cannonjs/components/CannonBody.ts
+++ b/plugins/extra/cannonjs/components/CannonBody.ts
@@ -5,6 +5,8 @@ export default class CannonBody extends SupEngine.ActorComponent {
   body: any;
   mass: number;
   fixedRotation: boolean;
+  group: number;
+  mask: number;
 
   actorPosition = new THREE.Vector3();
   actorOrientation = new THREE.Quaternion();
@@ -37,15 +39,18 @@ export default class CannonBody extends SupEngine.ActorComponent {
   setup(config: any) {
     this.mass = config.mass != null ? config.mass : 0;
     this.fixedRotation = config.fixedRotation != null ? config.fixedRotation : false;
+    this.group = config.group != null ? config.group : 1;
+    this.mask = config.mask != null ? config.mask : 1;
 
     this.actor.getGlobalPosition(this.actorPosition);
     this.actor.getGlobalOrientation(this.actorOrientation);
 
     this.body.mass = this.mass;
     this.body.type = this.mass === 0 ? (<any>window).CANNON.Body.STATIC : (<any>window).CANNON.Body.DYNAMIC;
-
     this.body.material = (<any>SupEngine).Cannon.World.defaultMaterial;
     this.body.fixedRotation = this.fixedRotation;
+    this.body.collisionFilterGroup = this.group;
+    this.body.collisionFilterMask = this.mask;
     this.body.updateMassProperties();
 
     // NOTE: config.offset was introduced in Superpowers 0.14
@@ -63,13 +68,13 @@ export default class CannonBody extends SupEngine.ActorComponent {
         z: config.offsetZ != null ? config.offsetZ : 0
       };
     }
-
     // config.orientation is introduced in this new version of Superpowers
+    let radian = Math.PI/180;
     if (config.orientation != null) {
         this.orientation = {
-            x: config.orientation.x,
-            y: config.orientation.y,
-            z: config.orientation.z
+            x: config.orientation.x * radian,
+            y: config.orientation.y * radian,
+            z: config.orientation.z * radian
         };
     } else {
         this.orientation = { x: 0, y: 0, z: 0 };
@@ -109,6 +114,7 @@ export default class CannonBody extends SupEngine.ActorComponent {
     }
     this.body.position.set(this.actorPosition.x, this.actorPosition.y, this.actorPosition.z);
     this.body.shapeOffsets[0].copy(this.offset);
+    this.body.shapeOrientations[0].setFromEuler(this.orientation.x, this.orientation.y, this.orientation.z);
     this.body.quaternion.set(this.actorOrientation.x, this.actorOrientation.y, this.actorOrientation.z, this.actorOrientation.w);
   }
 

--- a/plugins/extra/cannonjs/components/CannonBody.ts
+++ b/plugins/extra/cannonjs/components/CannonBody.ts
@@ -14,8 +14,8 @@ export default class CannonBody extends SupEngine.ActorComponent {
   shape: string;
 
   // attributes common to each shape
-  offset: { x: number; y: number; z: number; };
-  orientation: { x: number; y: number; z: number };
+  positionOffset: { x: number; y: number; z: number; };
+  orientationOffset: { x: number; y: number; z: number };
 
   // Box
   halfSize: { x: number; y: number; z: number; };
@@ -55,30 +55,28 @@ export default class CannonBody extends SupEngine.ActorComponent {
 
     // NOTE: config.offset was introduced in Superpowers 0.14
     // to merge config.offsetX, .offsetY and .offsetZ
-    if (config.offset != null) {
-      this.offset = {
-        x: config.offset.x,
-        y: config.offset.y,
-        z: config.offset.z
-      };
+    if (config.positionOffset != null) {
+        this.positionOffset = config.positionOffset;
+    } else if (config.offset != null) {
+      this.positionOffset = config.offset;
     } else {
-      this.offset = {
+      this.positionOffset = {
         x: config.offsetX != null ? config.offsetX : 0,
         y: config.offsetY != null ? config.offsetY : 0,
         z: config.offsetZ != null ? config.offsetZ : 0
       };
     }
-    // config.orientation is introduced in this new version of Superpowers
-    let radian = Math.PI/180;
-    if (config.orientation != null) {
-        this.orientation = {
-            x: config.orientation.x * radian,
-            y: config.orientation.y * radian,
-            z: config.orientation.z * radian
-        };
+    // config.orientation is introduced in the version 0.20 of Superpowers
+    if (config.orientationOffset != null) {
+        this.orientationOffset = config.orientationOffset;
     } else {
-        this.orientation = { x: 0, y: 0, z: 0 };
+        this.orientationOffset = { x: 0, y: 0, z: 0 };
     }
+    // we correct the angle
+    let radian = Math.PI/180;
+    this.orientationOffset.x *= radian;
+    this.orientationOffset.y *= radian;
+    this.orientationOffset.z *= radian;
 
     this.shape = config.shape;
     switch (this.shape) {
@@ -86,11 +84,7 @@ export default class CannonBody extends SupEngine.ActorComponent {
         // NOTE: config.halfSize was introduced in Superpowers 0.14
         // to merge config.halfWidth, .halfHeight and .halfDepth
         if (config.halfSize != null) {
-          this.halfSize = {
-            x: config.halfSize.x,
-            y: config.halfSize.y,
-            z: config.halfSize.z
-          };
+          this.halfSize = config.halfSize;
         } else {
           this.halfSize = {
             x: config.halfWidth != null ? config.halfWidth : 0.5,
@@ -113,8 +107,8 @@ export default class CannonBody extends SupEngine.ActorComponent {
         break;
     }
     this.body.position.set(this.actorPosition.x, this.actorPosition.y, this.actorPosition.z);
-    this.body.shapeOffsets[0].copy(this.offset);
-    this.body.shapeOrientations[0].setFromEuler(this.orientation.x, this.orientation.y, this.orientation.z);
+    this.body.shapeOffsets[0].copy(this.positionOffset);
+    this.body.shapeOrientations[0].setFromEuler(this.orientationOffset.x, this.orientationOffset.y, this.orientationOffset.z);
     this.body.quaternion.set(this.actorOrientation.x, this.actorOrientation.y, this.actorOrientation.z, this.actorOrientation.w);
   }
 

--- a/plugins/extra/cannonjs/components/CannonBodyMarker.ts
+++ b/plugins/extra/cannonjs/components/CannonBodyMarker.ts
@@ -16,16 +16,14 @@ class CannonBodyMarker extends SupEngine.ActorComponent {
 
   setBox(orientation: any, halfSize: any) {
     if (this.mesh != null) this._clearRenderer();
-
     let geometry = new THREE.BoxGeometry(halfSize.x * 2, halfSize.y * 2, halfSize.z * 2);
     let material = new THREE.MeshBasicMaterial({ wireframe: true, color: 0xf459e4, transparent: true, opacity: 0.2 });
     this.mesh = new THREE.Mesh(geometry, material);
-    let euler = Math.PI/180;
-    this.mesh.quaternion.setFromEuler(new THREE.Euler( orientation.x*euler, orientation.y*euler, orientation.z*euler ));
+    let radian = Math.PI/180;
+    this.mesh.quaternion.setFromEuler(new THREE.Euler(orientation.x*radian, orientation.y*radian, orientation.z*radian));
     this.actor.threeObject.add(this.mesh);
     this.mesh.updateMatrixWorld(false);
   }
-
   setSphere(radius: number) {
     if (this.mesh != null) this._clearRenderer();
     let geometry = new THREE.SphereGeometry(radius);
@@ -34,15 +32,13 @@ class CannonBodyMarker extends SupEngine.ActorComponent {
     this.actor.threeObject.add(this.mesh);
     this.mesh.updateMatrixWorld(false);
   }
-
   setCylinder(orientation: any, radius: number, height: number, segments: number) {
     if (this.mesh != null) this._clearRenderer();
-
     let geometry = new THREE.CylinderGeometry(radius, radius, height, segments);
     let material = new THREE.MeshBasicMaterial({ wireframe: true, color: 0xf459e4, transparent: true, opacity: 0.2 });
     this.mesh = new THREE.Mesh(geometry, material);
-    let euler = Math.PI/180;
-    this.mesh.quaternion.setFromEuler(new THREE.Euler( orientation.x*euler, orientation.y*euler, orientation.z*euler ));
+    let radian = Math.PI/180;
+    this.mesh.quaternion.setFromEuler(new THREE.Euler((orientation.x+90)*radian, orientation.y*radian, orientation.z*radian));
     this.actor.threeObject.add(this.mesh);
     this.mesh.updateMatrixWorld(false);
   }

--- a/plugins/extra/cannonjs/components/CannonBodyMarker.ts
+++ b/plugins/extra/cannonjs/components/CannonBodyMarker.ts
@@ -14,19 +14,20 @@ class CannonBodyMarker extends SupEngine.ActorComponent {
 
   setIsLayerActive(active: boolean) { if (this.mesh != null) this.mesh.visible = active; }
 
-  setBox(halfSize: any) {
+  setBox(orientation: any, halfSize: any) {
     if (this.mesh != null) this._clearRenderer();
 
     let geometry = new THREE.BoxGeometry(halfSize.x * 2, halfSize.y * 2, halfSize.z * 2);
     let material = new THREE.MeshBasicMaterial({ wireframe: true, color: 0xf459e4, transparent: true, opacity: 0.2 });
     this.mesh = new THREE.Mesh(geometry, material);
+    let euler = Math.PI/180;
+    this.mesh.quaternion.setFromEuler(new THREE.Euler( orientation.x*euler, orientation.y*euler, orientation.z*euler ));
     this.actor.threeObject.add(this.mesh);
     this.mesh.updateMatrixWorld(false);
   }
 
   setSphere(radius: number) {
     if (this.mesh != null) this._clearRenderer();
-
     let geometry = new THREE.SphereGeometry(radius);
     let material = new THREE.MeshBasicMaterial({ wireframe: true, color: 0xf459e4, transparent: true, opacity: 0.2 });
     this.mesh = new THREE.Mesh(geometry, material);
@@ -34,13 +35,14 @@ class CannonBodyMarker extends SupEngine.ActorComponent {
     this.mesh.updateMatrixWorld(false);
   }
 
-  setCylinder(radius: number, height: number) {
+  setCylinder(orientation: any, radius: number, height: number, segments: number) {
     if (this.mesh != null) this._clearRenderer();
 
-    let geometry = new THREE.CylinderGeometry(radius, radius, height);
+    let geometry = new THREE.CylinderGeometry(radius, radius, height, segments);
     let material = new THREE.MeshBasicMaterial({ wireframe: true, color: 0xf459e4, transparent: true, opacity: 0.2 });
     this.mesh = new THREE.Mesh(geometry, material);
-    this.mesh.quaternion.setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 2);
+    let euler = Math.PI/180;
+    this.mesh.quaternion.setFromEuler(new THREE.Euler( orientation.x*euler, orientation.y*euler, orientation.z*euler ));
     this.actor.threeObject.add(this.mesh);
     this.mesh.updateMatrixWorld(false);
   }

--- a/plugins/extra/cannonjs/components/CannonBodyMarker.ts
+++ b/plugins/extra/cannonjs/components/CannonBodyMarker.ts
@@ -14,13 +14,13 @@ class CannonBodyMarker extends SupEngine.ActorComponent {
 
   setIsLayerActive(active: boolean) { if (this.mesh != null) this.mesh.visible = active; }
 
-  setBox(orientation: any, halfSize: any) {
+  setBox(orientationOffset: any, halfSize: any) {
     if (this.mesh != null) this._clearRenderer();
     let geometry = new THREE.BoxGeometry(halfSize.x * 2, halfSize.y * 2, halfSize.z * 2);
     let material = new THREE.MeshBasicMaterial({ wireframe: true, color: 0xf459e4, transparent: true, opacity: 0.2 });
     this.mesh = new THREE.Mesh(geometry, material);
     let radian = Math.PI/180;
-    this.mesh.quaternion.setFromEuler(new THREE.Euler(orientation.x*radian, orientation.y*radian, orientation.z*radian));
+    this.mesh.quaternion.setFromEuler(new THREE.Euler(orientationOffset.x*radian, orientationOffset.y*radian, orientationOffset.z*radian));
     this.actor.threeObject.add(this.mesh);
     this.mesh.updateMatrixWorld(false);
   }
@@ -32,19 +32,19 @@ class CannonBodyMarker extends SupEngine.ActorComponent {
     this.actor.threeObject.add(this.mesh);
     this.mesh.updateMatrixWorld(false);
   }
-  setCylinder(orientation: any, radius: number, height: number, segments: number) {
+  setCylinder(orientationOffset: any, radius: number, height: number, segments: number) {
     if (this.mesh != null) this._clearRenderer();
     let geometry = new THREE.CylinderGeometry(radius, radius, height, segments);
     let material = new THREE.MeshBasicMaterial({ wireframe: true, color: 0xf459e4, transparent: true, opacity: 0.2 });
     this.mesh = new THREE.Mesh(geometry, material);
     let radian = Math.PI/180;
-    this.mesh.quaternion.setFromEuler(new THREE.Euler((orientation.x+90)*radian, orientation.y*radian, orientation.z*radian));
+    this.mesh.quaternion.setFromEuler(new THREE.Euler((orientationOffset.x+90)*radian, orientationOffset.y*radian, orientationOffset.z*radian));
     this.actor.threeObject.add(this.mesh);
     this.mesh.updateMatrixWorld(false);
   }
 
-  setOffset(offset: any) {
-    this.mesh.position.copy(offset);
+  setPositionOffset(positionOffset: any) {
+    this.mesh.position.copy(positionOffset);
     this.mesh.updateMatrixWorld(false);
   }
 

--- a/plugins/extra/cannonjs/components/CannonBodyMarkerUpdater.ts
+++ b/plugins/extra/cannonjs/components/CannonBodyMarkerUpdater.ts
@@ -12,35 +12,35 @@ export default class CannonBodyMarkerUpdater {
 
     switch (this.config.shape) {
       case "box" :
-        this.bodyRenderer.setBox(this.config.orientation, this.config.halfSize);
+        this.bodyRenderer.setBox(this.config.orientationOffset, this.config.halfSize);
         break;
       case "sphere" :
         this.bodyRenderer.setSphere(this.config.radius);
         break;
       case"cylinder":
-        this.bodyRenderer.setCylinder(this.config.orientation, this.config.radius, this.config.height, this.config.segments);
+        this.bodyRenderer.setCylinder(this.config.orientationOffset, this.config.radius, this.config.height, this.config.segments);
         break;
     }
-    this.bodyRenderer.setOffset(this.config.offset);
+    this.bodyRenderer.setPositionOffset(this.config.offset);
   }
 
   destroy() { /* Ignore */ }
 
   config_setProperty(path: string, value: any) {
-    if ((path.indexOf("orientation") !== -1 && this.config.shape === "box") || path.indexOf("halfSize") !== -1 || (path === "shape" && value === "box")) {
-      this.bodyRenderer.setBox(this.config.orientation, this.config.halfSize);
-      this.bodyRenderer.setOffset(this.config.offset);
+    if ((path.indexOf("orientationOffset") !== -1 && this.config.shape === "box") || path.indexOf("halfSize") !== -1 || (path === "shape" && value === "box")) {
+      this.bodyRenderer.setBox(this.config.orientationOffset, this.config.halfSize);
+      this.bodyRenderer.setPositionOffset(this.config.positionOffset);
     }
     if ((path === "radius" && this.config.shape === "sphere") || (path === "shape" && value === "sphere")) {
       this.bodyRenderer.setSphere(this.config.radius);
-      this.bodyRenderer.setOffset(this.config.offset);
+      this.bodyRenderer.setPositionOffset(this.config.positionOffset);
     }
-    if ((path.indexOf("orientation") !== -1 && this.config.shape === "cylinder") || (path === "radius" && this.config.shape === "cylinder") || (path === "shape" && value === "cylinder") || path === "height" || path === "segments") {
-      this.bodyRenderer.setCylinder(this.config.orientation, this.config.radius, this.config.height, this.config.segments);
-      this.bodyRenderer.setOffset(this.config.offset);
+    if ((path.indexOf("orientationOffset") !== -1 && this.config.shape === "cylinder") || (path === "radius" && this.config.shape === "cylinder") || (path === "shape" && value === "cylinder") || path === "height" || path === "segments") {
+      this.bodyRenderer.setCylinder(this.config.orientationOffset, this.config.radius, this.config.height, this.config.segments);
+      this.bodyRenderer.setPositionOffset(this.config.positionOffset);
     }
-    if (path.indexOf("offset") !== -1) {
-        this.bodyRenderer.setOffset(this.config.offset);
+    if (path.indexOf("positionOffset") !== -1) {
+        this.bodyRenderer.setPositionOffset(this.config.positionOffset);
     }
   }
 }

--- a/plugins/extra/cannonjs/components/CannonBodyMarkerUpdater.ts
+++ b/plugins/extra/cannonjs/components/CannonBodyMarkerUpdater.ts
@@ -12,13 +12,13 @@ export default class CannonBodyMarkerUpdater {
 
     switch (this.config.shape) {
       case "box" :
-        this.bodyRenderer.setBox(this.config.halfSize);
+        this.bodyRenderer.setBox(this.config.orientation, this.config.halfSize);
         break;
       case "sphere" :
         this.bodyRenderer.setSphere(this.config.radius);
         break;
       case"cylinder":
-        this.bodyRenderer.setCylinder(this.config.radius, this.config.height);
+        this.bodyRenderer.setCylinder(this.config.orientation, this.config.radius, this.config.height, this.config.segments);
         break;
     }
     this.bodyRenderer.setOffset(this.config.offset);
@@ -27,8 +27,8 @@ export default class CannonBodyMarkerUpdater {
   destroy() { /* Ignore */ }
 
   config_setProperty(path: string, value: any) {
-    if (path.indexOf("halfSize") !== -1 || (path === "shape" && value === "box")) {
-      this.bodyRenderer.setBox(this.config.halfSize);
+    if ((path.indexOf("orientation") !== -1 && this.config.shape === "box") ||path.indexOf("halfSize") !== -1 || (path === "shape" && value === "box")) {
+      this.bodyRenderer.setBox(this.config.orientation, this.config.halfSize);
       this.bodyRenderer.setOffset(this.config.offset);
     }
 
@@ -36,8 +36,8 @@ export default class CannonBodyMarkerUpdater {
       this.bodyRenderer.setOffset(this.config.offset);
     }
 
-    if ((path === "radius" && this.config.shape === "cylinder") || (path === "shape" && value === "cylinder") || path === "height") {
-      this.bodyRenderer.setCylinder(this.config.radius, this.config.height);
+    if ((path.indexOf("orientation") !== -1 && this.config.shape === "cylinder") || (path === "radius" && this.config.shape === "cylinder") || (path === "shape" && value === "cylinder") || path === "height" || path === "segments") {
+      this.bodyRenderer.setCylinder(this.config.orientation, this.config.radius, this.config.height, this.config.segments);
       this.bodyRenderer.setOffset(this.config.offset);
     }
 

--- a/plugins/extra/cannonjs/components/CannonBodyMarkerUpdater.ts
+++ b/plugins/extra/cannonjs/components/CannonBodyMarkerUpdater.ts
@@ -27,23 +27,20 @@ export default class CannonBodyMarkerUpdater {
   destroy() { /* Ignore */ }
 
   config_setProperty(path: string, value: any) {
-    if ((path.indexOf("orientation") !== -1 && this.config.shape === "box") ||path.indexOf("halfSize") !== -1 || (path === "shape" && value === "box")) {
+    if ((path.indexOf("orientation") !== -1 && this.config.shape === "box") || path.indexOf("halfSize") !== -1 || (path === "shape" && value === "box")) {
       this.bodyRenderer.setBox(this.config.orientation, this.config.halfSize);
       this.bodyRenderer.setOffset(this.config.offset);
     }
-
-    if (path.indexOf("offset") !== -1) {
+    if ((path === "radius" && this.config.shape === "sphere") || (path === "shape" && value === "sphere")) {
+      this.bodyRenderer.setSphere(this.config.radius);
       this.bodyRenderer.setOffset(this.config.offset);
     }
-
     if ((path.indexOf("orientation") !== -1 && this.config.shape === "cylinder") || (path === "radius" && this.config.shape === "cylinder") || (path === "shape" && value === "cylinder") || path === "height" || path === "segments") {
       this.bodyRenderer.setCylinder(this.config.orientation, this.config.radius, this.config.height, this.config.segments);
       this.bodyRenderer.setOffset(this.config.offset);
     }
-
-    if ((path === "radius" && this.config.shape === "sphere") || (path === "shape" && value === "sphere")) {
-      this.bodyRenderer.setSphere(this.config.radius);
-      this.bodyRenderer.setOffset(this.config.offset);
+    if (path.indexOf("offset") !== -1) {
+        this.bodyRenderer.setOffset(this.config.offset);
     }
   }
 }

--- a/plugins/extra/cannonjs/data/CannonShape.ts
+++ b/plugins/extra/cannonjs/data/CannonShape.ts
@@ -1,0 +1,54 @@
+export interface CannonShapePub {
+    id: string;
+    shape: string;
+    positionOffset: { x: number, y: number, z: number };
+    orientationOffset: { x: number, y: number, z: number };
+    halfSize: { x: number, y: number, z: number };
+    radius: number;
+    height: number;
+    segments: number;
+}
+
+export default class CannonShape extends SupCore.Data.Base.ListById {
+
+  static schema: SupCore.Data.Schema = {
+      shape: { type: "enum", items: ["box", "sphere", "cylinder"], mutable: true },
+      positionOffset: {
+        mutable: true,
+        type: "hash",
+        properties: {
+          x: { type: "number", mutable: true },
+          y: { type: "number", mutable: true },
+          z: { type: "number", mutable: true },
+        }
+      },
+      orientationOffset: {
+          mutable: true,
+          type: "hash",
+          properties: {
+              x: { type: "number", mutable: true },
+              y: { type: "number", mutable: true },
+              z: { type: "number", mutable: true }
+          }
+      },
+      halfSize: {
+        mutable: true,
+        type: "hash",
+        properties: {
+          x: { type: "number", min: 0, mutable: true },
+          y: { type: "number", min: 0, mutable: true },
+          z: { type: "number", min: 0, mutable: true },
+        }
+      },
+      radius: { type: "number", min: 0, mutable: true },
+      height: { type: "number", min: 0, mutable: true },
+      segments: { type: "number", min: 3, mutable: true }
+  };
+
+  pub: CannonShapePub[];
+  byId: { [id: string]: CannonShapePub};
+
+  constructor(pub: CannonShapePub[]) {
+    super(pub, CannonShape.schema);
+  }
+}

--- a/plugins/extra/cannonjs/public/locales/en/componentEditors.json
+++ b/plugins/extra/cannonjs/public/locales/en/componentEditors.json
@@ -12,8 +12,8 @@
       "sphere": "Sphere",
       "cylinder": "Cylinder"
     },
-    "offset": "Offset",
-    "orientation": "Orientation",
+    "positionOffset": "Position Offset",
+    "orientationOffset": "Orientation Offset",
     "halfSize": "Half size",
     "radius": "Radius",
     "height": "Height",

--- a/plugins/extra/cannonjs/public/locales/en/componentEditors.json
+++ b/plugins/extra/cannonjs/public/locales/en/componentEditors.json
@@ -11,8 +11,10 @@
       "sphere": "Sphere",
       "cylinder": "Cylinder"
     },
+    "orientation": "Orientation",
     "halfSize": "Half size",
     "radius": "Radius",
-    "height": "Height"
+    "height": "Height",
+    "segments": "Segments"
   }
 }

--- a/plugins/extra/cannonjs/public/locales/en/componentEditors.json
+++ b/plugins/extra/cannonjs/public/locales/en/componentEditors.json
@@ -3,7 +3,8 @@
     "label": "Cannon Body",
     "mass": "Mass",
     "fixedRotation": "Fixed rotation",
-    "offset": "Offset",
+    "group": "Group",
+    "mask": "Mask",
     "shape": "Shape",
     "shapeType": "Type",
     "shapeOptions": {
@@ -11,6 +12,7 @@
       "sphere": "Sphere",
       "cylinder": "Cylinder"
     },
+    "offset": "Offset",
     "orientation": "Orientation",
     "halfSize": "Half size",
     "radius": "Radius",

--- a/plugins/extra/cannonjs/typescriptAPI/CANNON.d.ts.txt
+++ b/plugins/extra/cannonjs/typescriptAPI/CANNON.d.ts.txt
@@ -886,12 +886,12 @@ declare module CANNON {
         vertices: Vec3[];
         worldVertices: Vec3[];
         worldVerticesNeedsUpdate: boolean;
-        faces: number[];
+        faces: number[][];
         faceNormals: Vec3[];
         uniqueEdges: Vec3[];
         uniqueAxes: Vec3[];
 
-        constructor(points?: Vec3[], faces?: number[]);
+        constructor(points?: Vec3[], faces?: number[][]);
 
         computeEdges(): void;
         computeNormals(): void;


### PR DESCRIPTION
I've added the possibility to choose the number of segments for Cylinder
Collider and also the possibility to choose the orientation of the
Collider.

I've also change the order of the offset fields and put it in after the Shape header
If we can declare multiple shapes for the same CannonBody and move them and rotate them independently, then this would allow to create complexe physical shapes without using multiples CannonBodies to do so. And less CannonBodies means better performances.