### PR TITLE
Expose bounce property to Arcade Body 2D component editor

### DIFF
--- a/plugins/default/arcadePhysics2D/componentConfigs/ArcadeBody2DConfig.ts
+++ b/plugins/default/arcadePhysics2D/componentConfigs/ArcadeBody2DConfig.ts
@@ -7,6 +7,7 @@ export interface ConfigPub {
   width: number;
   height: number;
   offset: { x: number; y: number; };
+  bounce: { x: number; y: number; };
 
   tileMapAssetId: string;
   tileSetPropertyName: string;
@@ -31,6 +32,13 @@ export default class ArcadeBody2DConfig extends SupCore.Data.Base.ComponentConfi
         y: { type: "number", mutable: true },
       }
     },
+    bounce: {
+      type: "hash",
+      properties: {
+        x: { type: "number", mutable: true },
+        y: { type: "number", mutable: true },
+      }
+    },
 
     // TileMap
     tileMapAssetId: { type: "string?", mutable: true },
@@ -48,6 +56,7 @@ export default class ArcadeBody2DConfig extends SupCore.Data.Base.ComponentConfi
       width: 1,
       height: 1,
       offset: { x: 0, y: 0 },
+      bounce: { x: 0, y: 0 },
 
       tileMapAssetId: null,
       tileSetPropertyName: null,

--- a/plugins/default/arcadePhysics2D/componentEditors/ArcadeBody2DEditor.ts
+++ b/plugins/default/arcadePhysics2D/componentEditors/ArcadeBody2DEditor.ts
@@ -57,6 +57,18 @@ export default class ArcadeBody2DEditor {
       this.editConfig("setProperty", "offset.y", parseFloat(event.target.value));
     });
 
+    let bounceRow = SupClient.table.appendRow(this.tbody, SupClient.i18n.t("componentEditors:ArcadeBody2D.bounce"));
+    let bounceFields = SupClient.table.appendNumberFields(bounceRow.valueCell, [config.bounce.x, config.bounce.y]);
+    this.boxFields["bounce.x"] = bounceFields[0];
+    this.boxFields["bounce.x"].addEventListener("change", (event: any) => {
+      this.editConfig("setProperty", "bounce.x", parseFloat(event.target.value));
+    });
+
+    this.boxFields["bounce.y"] = bounceFields[1];
+    this.boxFields["bounce.y"].addEventListener("change", (event: any) => {
+      this.editConfig("setProperty", "bounce.y", parseFloat(event.target.value));
+    });
+
     // Tile Map boxFields
     this.tileMapFields = {};
 
@@ -112,6 +124,7 @@ export default class ArcadeBody2DEditor {
       this.boxFields["movable"].parentElement.parentElement.hidden = false;
       this.boxFields["width"].parentElement.parentElement.parentElement.hidden = false;
       this.boxFields["offset.x"].parentElement.parentElement.parentElement.hidden = false;
+      this.boxFields["bounce.x"].parentElement.parentElement.parentElement.hidden = false;
 
     } else {
       for (let fieldName in this.tileMapFields) this.tileMapFields[fieldName].parentElement.parentElement.hidden = false;
@@ -119,6 +132,7 @@ export default class ArcadeBody2DEditor {
       this.boxFields["movable"].parentElement.parentElement.hidden = true;
       this.boxFields["width"].parentElement.parentElement.parentElement.hidden = true;
       this.boxFields["offset.x"].parentElement.parentElement.parentElement.hidden = true;
+      this.boxFields["bounce.x"].parentElement.parentElement.parentElement.hidden = true;
     }
   }
 }

--- a/plugins/default/arcadePhysics2D/components/ArcadeBody2D.ts
+++ b/plugins/default/arcadePhysics2D/components/ArcadeBody2D.ts
@@ -49,8 +49,10 @@ export default class ArcadeBody2D extends SupEngine.ActorComponent {
       this.offsetX = config.offset.x;
       this.offsetY = config.offset.y;
     }
-    if (config.bounceX != null) this.bounceX = config.bounceX;
-    if (config.bounceY != null) this.bounceY = config.bounceY;
+    if (config.bounce != null) {
+        this.bounceX = config.bounce.x;
+        this.bounceY = config.bounce.y;
+    }
 
     this.actorPosition = this.actor.getGlobalPosition(new THREE.Vector3());
     this.position = this.actorPosition.clone();

--- a/plugins/default/arcadePhysics2D/public/locales/en/componentEditors.json
+++ b/plugins/default/arcadePhysics2D/public/locales/en/componentEditors.json
@@ -10,6 +10,7 @@
     "movable": "Movable",
     "size": "Size",
     "offset": "Offset",
+    "bounce": "Bounce",
 
     "tileMap": "Tile Map",
     "tileSetProperty": "Tile Set Property",

--- a/plugins/default/sprite/componentConfigs/SpriteRendererConfig.ts
+++ b/plugins/default/sprite/componentConfigs/SpriteRendererConfig.ts
@@ -7,6 +7,7 @@ export interface SpriteRendererConfigPub {
   color: string;
   overrideOpacity: boolean; opacity: number;
   materialType: string; shaderAssetId: string;
+  blending: string;
 }
 
 export default class SpriteRendererConfig extends SupCore.Data.Base.ComponentConfig {
@@ -24,7 +25,8 @@ export default class SpriteRendererConfig extends SupCore.Data.Base.ComponentCon
     overrideOpacity: { type: "boolean", mutable: true },
     opacity: { type: "number?", min: 0, max: 1, mutable: true },
     materialType: { type: "enum", items: ["basic", "phong", "shader"], mutable: true },
-    shaderAssetId: { type: "string?", min: 0, mutable: true }
+    shaderAssetId: { type: "string?", min: 0, mutable: true },
+    blending: { type: "enum", items: ["normal", "additive", "subtractive", "multiply"], mutable: true}
   };
 
   static create() {
@@ -36,7 +38,8 @@ export default class SpriteRendererConfig extends SupCore.Data.Base.ComponentCon
       castShadow: false, receiveShadow: false,
       color: "ffffff",
       overrideOpacity: false, opacity: null,
-      materialType: "basic", shaderAssetId: null
+      materialType: "basic", shaderAssetId: null,
+      blending: "normal"
     };
     return emptyConfig;
   }
@@ -47,6 +50,9 @@ export default class SpriteRendererConfig extends SupCore.Data.Base.ComponentCon
 
     if (pub.formatVersion == null) {
       pub.formatVersion = 1;
+
+      // NOTE: Blend modes added by GMG - fix this because I probably did it wrongly
+      if (pub.blending == null) pub.blending = "normal";
 
       // NOTE: Settings introduced in Superpowers 0.8
       if (pub.overrideOpacity == null) pub.overrideOpacity = false;

--- a/plugins/default/sprite/componentEditors/SpriteRendererEditor.ts
+++ b/plugins/default/sprite/componentEditors/SpriteRendererEditor.ts
@@ -147,6 +147,12 @@ export default class SpriteRendererEditor {
     (this.transparentField.children[0] as HTMLOptionElement).hidden = true;
     this.transparentField.addEventListener("change", (event) => {
       let opacity = this.transparentField.value === "transparent" ? 1 : null;
+      if (this.transparentField.value === "transparent") {
+        this.blendingSelectBox.disabled = false;
+      } else {
+        this.blendingSelectBox.value = "normal";
+        this.blendingSelectBox.disabled = true;
+      }
       this.editConfig("setProperty", "opacity", opacity);
     });
 
@@ -155,6 +161,21 @@ export default class SpriteRendererEditor {
       this.editConfig("setProperty", "opacity", parseFloat(event.target.value));
     });
     this.updateOpacityField();
+
+    let blendingRow = SupClient.table.appendRow(
+        tbody,
+        SupClient.i18n.t("componentEditors:SpriteRenderer.blending"),
+        { title: SupClient.i18n.t("componentEditors:SpriteRenderer.blendingTitle") });
+    this.blendingSelectBox = SupClient.table.appendSelectBox(blendingRow.valueCell, {
+        "normal": "Normal",
+        "additive": "Additive",
+        "subtractive": "Subtractive",
+        "multiply": "Multiply"
+        }, config.blending);
+    this.blendingSelectBox.addEventListener("change", (event: any) => {
+      this.editConfig("setProperty", "blending", event.target.value);
+    });
+    this.blendingSelectBox.disabled = true;
 
     let materialRow = SupClient.table.appendRow(tbody, SupClient.i18n.t("componentEditors:SpriteRenderer.material"));
     this.materialSelectBox = SupClient.table.appendSelectBox(materialRow.valueCell, { "basic": "Basic", "phong": "Phong", "shader": "Shader" }, config.materialType);
@@ -175,17 +196,6 @@ export default class SpriteRendererEditor {
     });
     this.shaderButtonElt.disabled = this.shaderAssetId == null;
     this.shaderRow.hidden = config.materialType !== "shader";
-
-    let blendingRow = SupClient.table.appendRow(tbody, SupClient.i18n.t("componentEditors:SpriteRenderer.blending"));
-    this.blendingSelectBox = SupClient.table.appendSelectBox(blendingRow.valueCell, {
-        "normal": "Normal",
-        "additive": "Additive",
-        "subtractive": "Subtractive",
-        "multiply": "Multiply"
-        }, config.blending);
-    this.blendingSelectBox.addEventListener("change", (event: any) => {
-      this.editConfig("setProperty", "blending", event.target.value);
-    });
 
     this.projectClient.subEntries(this);
   }
@@ -381,6 +391,8 @@ export default class SpriteRendererEditor {
       } else {
         this.transparentField.value = "opaque";
         this.opacityFields.numberField.parentElement.hidden = true;
+        this.blendingSelectBox.value = "normal";
+        this.blendingSelectBox.disabled = true;
       }
     }
   }

--- a/plugins/default/sprite/componentEditors/SpriteRendererEditor.ts
+++ b/plugins/default/sprite/componentEditors/SpriteRendererEditor.ts
@@ -32,6 +32,8 @@ export default class SpriteRendererEditor {
   shaderTextField: HTMLInputElement;
   shaderButtonElt: HTMLButtonElement;
 
+  blendingSelectBox: HTMLSelectElement;
+
   asset: SpriteAsset;
   overrideOpacity: boolean;
   opacity: number;
@@ -174,6 +176,17 @@ export default class SpriteRendererEditor {
     this.shaderButtonElt.disabled = this.shaderAssetId == null;
     this.shaderRow.hidden = config.materialType !== "shader";
 
+    let blendingRow = SupClient.table.appendRow(tbody, SupClient.i18n.t("componentEditors:SpriteRenderer.blending"));
+    this.blendingSelectBox = SupClient.table.appendSelectBox(blendingRow.valueCell, {
+        "normal": "Normal",
+        "additive": "Additive",
+        "subtractive": "Subtractive",
+        "multiply": "Multiply"
+        }, config.blending);
+    this.blendingSelectBox.addEventListener("change", (event: any) => {
+      this.editConfig("setProperty", "blending", event.target.value);
+    });
+
     this.projectClient.subEntries(this);
   }
 
@@ -250,6 +263,10 @@ export default class SpriteRendererEditor {
         if (value != null) this.shaderTextField.value = this.projectClient.entries.getPathFromId(value);
         else this.shaderTextField.value = "";
         break;
+
+      case "blending":
+        this.blendingSelectBox.value = value;
+        break;
     }
   }
 
@@ -262,6 +279,7 @@ export default class SpriteRendererEditor {
     this.colorPicker.disabled = false;
     this.materialSelectBox.disabled = false;
     this.shaderTextField.disabled = false;
+    this.blendingSelectBox.disabled = false;
 
     if (entries.byId[this.spriteAssetId] != null) {
       this.spriteTextField.value = entries.getPathFromId(this.spriteAssetId);

--- a/plugins/default/sprite/components/SpriteRenderer.ts
+++ b/plugins/default/sprite/components/SpriteRenderer.ts
@@ -18,6 +18,7 @@ export default class SpriteRenderer extends SupEngine.ActorComponent {
   material: THREE.MeshBasicMaterial|THREE.MeshPhongMaterial|THREE.ShaderMaterial;
   materialType = "basic";
   shaderAsset: any;
+  blending = "normal";
   threeMesh: THREE.Mesh;
   horizontalFlip = false;
   verticalFlip = false;
@@ -38,7 +39,7 @@ export default class SpriteRenderer extends SupEngine.ActorComponent {
     super(actor, "SpriteRenderer");
   }
 
-  setSprite(asset: SpriteAssetPub, materialType?: string, customShader?: any) {
+  setSprite(asset: SpriteAssetPub, materialType?: string, customShader?: any, blending?: string) {
     this._clearMesh();
 
     this.asset = asset;
@@ -77,6 +78,7 @@ export default class SpriteRenderer extends SupEngine.ActorComponent {
     }
     this.material.side = THREE.DoubleSide;
     this.setColor(this.color.r, this.color.g, this.color.b);
+    if (blending != null) this.setBlending(blending);
 
     // TEMP
     // this.asset.textures["map"].wrapS = THREE.RepeatWrapping;
@@ -132,6 +134,23 @@ export default class SpriteRenderer extends SupEngine.ActorComponent {
       this.material.opacity = 1;
     }
     this.material.needsUpdate = true;
+  }
+
+  setBlending(blending: string){
+      switch (blending) {
+          case "normal":
+            this.material.blending = THREE.NormalBlending;
+            break;
+          case "additive":
+            this.material.blending = THREE.AdditiveBlending;
+            break;
+          case "subtractive":
+            this.material.blending = THREE.SubtractiveBlending;
+            break;
+          case "multiply":
+            this.material.blending = THREE.MultiplyBlending;
+            break;
+      }
   }
 
   setHorizontalFlip(horizontalFlip: boolean) {

--- a/plugins/default/sprite/components/SpriteRendererUpdater.ts
+++ b/plugins/default/sprite/components/SpriteRendererUpdater.ts
@@ -16,6 +16,7 @@ export default class SpriteRendererUpdater {
   materialType: string;
   shaderAssetId: string;
   shaderPub: any;
+  blending: string;
   overrideOpacity = false;
   opacity: number;
 
@@ -41,6 +42,7 @@ export default class SpriteRendererUpdater {
     this.animationId = config.animationId;
     this.materialType = config.materialType;
     this.shaderAssetId = config.shaderAssetId;
+    this.blending = config.blending;
 
     this.spriteRenderer.horizontalFlip = config.horizontalFlip;
     this.spriteRenderer.verticalFlip = config.verticalFlip;
@@ -101,7 +103,7 @@ export default class SpriteRendererUpdater {
       return;
     }
 
-    this.spriteRenderer.setSprite(this.spriteAsset.pub, this.materialType, this.shaderPub);
+    this.spriteRenderer.setSprite(this.spriteAsset.pub, this.materialType, this.shaderPub, this.blending);
     if (this.animationId != null) this._playAnimation();
   }
 
@@ -270,6 +272,11 @@ export default class SpriteRendererUpdater {
         this.spriteRenderer.setSprite(null);
 
         if (this.shaderAssetId != null) this.client.subAsset(this.shaderAssetId, "shader", this.shaderSubscriber);
+        break;
+
+      case "blending":
+        this.blending = value;
+        this.spriteRenderer.setBlending(value);
         break;
     }
   }

--- a/plugins/default/sprite/public/locales/en/componentEditors.json
+++ b/plugins/default/sprite/public/locales/en/componentEditors.json
@@ -16,6 +16,7 @@
     "opaque": "Opaque",
     "material": "Material",
     "shader": "Shader",
-    "blending": "Blending"
+    "blending": "Blending",
+    "blendingTitle": "For blending modes other than Normal, you must set the sprite as Transparent"
   }
 }

--- a/plugins/default/sprite/public/locales/en/componentEditors.json
+++ b/plugins/default/sprite/public/locales/en/componentEditors.json
@@ -15,6 +15,7 @@
     "transparent": "Transparent",
     "opaque": "Opaque",
     "material": "Material",
-    "shader": "Shader"
+    "shader": "Shader",
+    "blending": "Blending"
   }
 }

--- a/plugins/default/sprite/runtime/SpriteRenderer.ts
+++ b/plugins/default/sprite/runtime/SpriteRenderer.ts
@@ -23,7 +23,7 @@ export function setupComponent(player: SupRuntime.Player, component: any, config
         shader = shaderAsset.__inner;
       }
     }
-    component.setSprite(sprite.__inner, config.materialType, shader);
+    component.setSprite(sprite.__inner, config.materialType, shader, config.blending);
 
     if (config.animationId != null) {
       // FIXME: should we load sprite with SupCore.Data?

--- a/plugins/default/sprite/typescriptAPI/Sup.SpriteRenderer.d.ts.txt
+++ b/plugins/default/sprite/typescriptAPI/Sup.SpriteRenderer.d.ts.txt
@@ -5,7 +5,7 @@ declare namespace Sup {
 
     getSprite(): Sprite;
     setSprite(pathOrAsset: string|Sprite): SpriteRenderer;
-    setSprite(pathOrAsset: string|Sprite, materialType?: SpriteRenderer.MaterialType, shaderPathOrAsset?: string|Shader): SpriteRenderer;
+    setSprite(pathOrAsset: string|Sprite, materialType?: SpriteRenderer.MaterialType, shaderPathOrAsset?: string|Shader, blending?: SpriteRenderer.Blending): SpriteRenderer;
     
     getMaterialType(): SpriteRenderer.MaterialType;
     getShader(): Shader;
@@ -17,6 +17,8 @@ declare namespace Sup {
     getVerticalFlip(): boolean;
     getOpacity(): number;
     setOpacity(opacity: number): SpriteRenderer;
+    setBlending(blending: string): SpriteRenderer;
+    
     getColor(): Sup.Color;
     setColor(color: Sup.Color): SpriteRenderer;
     setColor(r: number, g: number, b: number): SpriteRenderer;
@@ -38,6 +40,7 @@ declare namespace Sup {
   }
 
   namespace SpriteRenderer {
-    enum MaterialType { Basic, Phong, Shader }
+    enum MaterialType { Basic, Phong, Shader };
+    enum Blending { Normal, Additive, Subtractive, Multiply };
   }
 }

--- a/plugins/default/sprite/typescriptAPI/Sup.SpriteRenderer.ts.txt
+++ b/plugins/default/sprite/typescriptAPI/Sup.SpriteRenderer.ts.txt
@@ -1,5 +1,6 @@
 namespace Sup {
   let materialTypes = ["basic", "phong", "shader"];
+  let blendings = ["normal", "additive", "subtractive", "multiply"];
 
   export class SpriteRenderer extends Sup.ActorComponent {
     constructor(actor: Actor, pathOrAsset?: string|Sprite, materialIndex?: number, shaderPathOrAsset?: string|Shader) {
@@ -15,7 +16,7 @@ namespace Sup {
     }
 
     getSprite() { return (this.__inner.asset != null) ? this.__inner.asset.__outer : null; }
-    setSprite(pathOrAsset: string|Sprite, materialIndex?: number, shaderPathOrAsset?: string|Shader) {
+    setSprite(pathOrAsset: string|Sprite, materialIndex?: number, shaderPathOrAsset?: string|Shader, blending?: number) {
       let material: string;
       if (materialIndex != null) material = materialTypes[materialIndex];
 
@@ -31,7 +32,10 @@ namespace Sup {
       let shaderAsset: Shader;
       if (shaderPathOrAsset != null)
         shaderAsset = (typeof shaderPathOrAsset === "string") ? get(shaderPathOrAsset, Shader) : <Shader>shaderPathOrAsset;
-
+      
+      let blending: string;
+      if (blending != null) setBlending(blendings[blending]);
+      
       this.__inner.setSprite((spriteAsset != null) ? spriteAsset.__inner : null, material, (shaderAsset != null) ? shaderAsset.__inner : null);
       return this;
     }
@@ -46,6 +50,8 @@ namespace Sup {
     getVerticalFlip() { return this.__inner.verticalFlip; }
     getOpacity() { return this.__inner.opacity; }
     setOpacity(opacity) { this.__inner.setOpacity(opacity); return this; }
+    setBlending(blending) { this.__inner.setBlending(blending); return this; }
+
     getColor() { return new Color(this.__inner.color.r, this.__inner.color.g, this.__inner.color.b); }
     setColor(r, g, b) {
       if (g == null && b == null) {
@@ -73,5 +79,6 @@ namespace Sup {
 
   export namespace SpriteRenderer {
     export enum MaterialType { Basic, Phong, Shader };
+    export enum Blending { Normal, Additive, Subtractive, Multiply };
   }
 }


### PR DESCRIPTION
I noticed that the Bounce property was the only one not exposed to the component editor, and after looking at harraps' pull request for CannonBody, I thought it would be doable for me to add it. 

Please bear in mind, I have only been using superpowers and TypeScript for about a week, so I have probably made some errors. I have mostly just been copying from existing code without really understanding what it all does.