### PR TITLE
Support for Multiple Animations (modelrender)

### DIFF
--- a/plugins/default/model/typescriptAPI/Sup.ModelRenderer.d.ts.txt
+++ b/plugins/default/model/typescriptAPI/Sup.ModelRenderer.d.ts.txt
@@ -1,7 +1,8 @@
-interface AnimationTimes {
+interface AnimationItem {
   name: string;
-  time: number;
-  ignoreFilter?: RegExp;
+  time?: number;
+  looping?: boolean;
+  ignoreBoneNameFilter?: RegExp;
 }
 
 declare namespace Sup {
@@ -27,9 +28,9 @@ declare namespace Sup {
     getAnimation(): string;
     setAnimation(animationName: string, looping?: boolean): ModelRenderer;
     setAnimationTime(time: number): ModelRenderer;
-    setAnimationsAndTimes(animationList: Array<AnimationTimes>): ModelRenderer;
     getAnimationTime(): number;
     getAnimationDuration(): number;
+    setMultipleAnimations(animationItemList: Array<AnimationItem>): ModelRenderer;    
 
     isAnimationPlaying(): boolean;
     playAnimation(looping?: boolean): ModelRenderer;

--- a/plugins/default/model/typescriptAPI/Sup.ModelRenderer.d.ts.txt
+++ b/plugins/default/model/typescriptAPI/Sup.ModelRenderer.d.ts.txt
@@ -1,3 +1,9 @@
+interface AnimationTimes {
+  name: string;
+  time: number;
+  ignoreFilter?: RegExp;
+}
+
 declare namespace Sup {
   class ModelRenderer extends ActorComponent {
     constructor(actor: Actor, pathOrAsset?: string|Model);
@@ -21,6 +27,7 @@ declare namespace Sup {
     getAnimation(): string;
     setAnimation(animationName: string, looping?: boolean): ModelRenderer;
     setAnimationTime(time: number): ModelRenderer;
+    setAnimationsAndTimes(animationList: Array<AnimationTimes>): ModelRenderer;
     getAnimationTime(): number;
     getAnimationDuration(): number;
 

--- a/plugins/default/model/typescriptAPI/Sup.ModelRenderer.ts.txt
+++ b/plugins/default/model/typescriptAPI/Sup.ModelRenderer.ts.txt
@@ -64,7 +64,7 @@ namespace Sup {
     }
 
     setAnimation(animationName, looping) { this.__inner.setAnimation(animationName, looping); return this }
-    setAnimationsAndTimes(animationList) { this.__inner.setAnimationsAndTimes(animationList); return this }
+    setMultipleAnimations(animationItemList) { this.__inner.setMultipleAnimations(animationItemList); return this }
     getAnimation() { return this.__inner.getAnimation() }
     setAnimationTime(time) { this.__inner.setAnimationTime(time); return this }
     getAnimationTime() { return this.__inner.getAnimationTime() }

--- a/plugins/default/model/typescriptAPI/Sup.ModelRenderer.ts.txt
+++ b/plugins/default/model/typescriptAPI/Sup.ModelRenderer.ts.txt
@@ -64,6 +64,7 @@ namespace Sup {
     }
 
     setAnimation(animationName, looping) { this.__inner.setAnimation(animationName, looping); return this }
+    setAnimationsAndTimes(animationList) { this.__inner.setAnimationsAndTimes(animationList); return this }
     getAnimation() { return this.__inner.getAnimation() }
     setAnimationTime(time) { this.__inner.setAnimationTime(time); return this }
     getAnimationTime() { return this.__inner.getAnimationTime() }


### PR DESCRIPTION
Added a function in modelrender to support multiple animations it´s kinda like setAnimation+setAnimationTime(optional) used multiple times for each animation with the exception that it uses updatePose immediately and is able to pass a ignoreBoneNameFilter(RegExp) to the updatePose function so the animations can ignore to update certain bones and in that way you can use

```
let animations = [];
animations.push({ name:'run', time: this.ani['run'].cur_time });
animations.push({ name:'aimGunZ', time: aimAngleZ, ignoreBoneNameFilter: /legs|hips/g });
this.actor.modelRenderer.setMultipleAnimations(animations);
```

animation 1 would set the run pose on all bones
animation 2 would set aim gun pose for all bones except those who has legs or hips in their name

this is my first week programming with typescript and with the superpower-game source code
hopefully it isn´t to bad.