### PR TITLE
scene: focus actor enhancement

### DIFF
--- a/SupEngine/SupEngine.d.ts
+++ b/SupEngine/SupEngine.d.ts
@@ -139,6 +139,7 @@ declare namespace SupEngine {
 
   interface MouseButtonState {
     isDown: boolean;
+    dblClicked: boolean;
     wasJustPressed: boolean;
     wasJustReleased: boolean;
   }

--- a/SupEngine/SupEngine.d.ts
+++ b/SupEngine/SupEngine.d.ts
@@ -139,7 +139,7 @@ declare namespace SupEngine {
 
   interface MouseButtonState {
     isDown: boolean;
-    dblClicked: boolean;
+    doubleClicked: boolean;
     wasJustPressed: boolean;
     wasJustReleased: boolean;
   }

--- a/SupEngine/src/Input.ts
+++ b/SupEngine/src/Input.ts
@@ -9,6 +9,7 @@ interface KeyState {
 
 interface MouseButtonState {
   isDown: boolean;
+  dblClicked: boolean;
   wasJustPressed: boolean;
   wasJustReleased: boolean;
 }
@@ -89,6 +90,7 @@ export default class Input extends EventEmitter {
     // Mouse
     this.canvas.addEventListener("mousemove", this.onMouseMove);
     this.canvas.addEventListener("mousedown", this.onMouseDown);
+    this.canvas.addEventListener("dblclick", this.onMouseDblClick);
     document.addEventListener("mouseup", this.onMouseUp);
     this.canvas.addEventListener("contextmenu", this.onContextMenu);
     this.canvas.addEventListener("DOMMouseScroll", this.onMouseWheel);
@@ -177,7 +179,7 @@ export default class Input extends EventEmitter {
     // Mouse
     this.newScrollDelta = 0;
     for (let i = 0; i <= 6; i++) {
-      this.mouseButtons[i] = { isDown: false, wasJustPressed: false, wasJustReleased: false };
+      this.mouseButtons[i] = { isDown: false,dblClicked: false, wasJustPressed: false, wasJustReleased: false };
       this.mouseButtonsDown[i] = false;
     }
 
@@ -349,6 +351,11 @@ export default class Input extends EventEmitter {
 
     if (this.wantsFullscreen && !this.wasFullscreen) this._doGoFullscreen();
     if (this.wantsPointerLock && !this.wasPointerLocked) this._doPointerLock();
+  };
+
+  private onMouseDblClick = (event: MouseEvent) => {
+    event.preventDefault();
+    this.mouseButtons[event.button].dblClicked = true;
   };
 
   private onContextMenu = (event: Event) => {

--- a/SupEngine/src/Input.ts
+++ b/SupEngine/src/Input.ts
@@ -9,7 +9,7 @@ interface KeyState {
 
 interface MouseButtonState {
   isDown: boolean;
-  dblClicked: boolean;
+  doubleClicked: boolean;
   wasJustPressed: boolean;
   wasJustReleased: boolean;
 }
@@ -179,7 +179,7 @@ export default class Input extends EventEmitter {
     // Mouse
     this.newScrollDelta = 0;
     for (let i = 0; i <= 6; i++) {
-      this.mouseButtons[i] = { isDown: false,dblClicked: false, wasJustPressed: false, wasJustReleased: false };
+      this.mouseButtons[i] = { isDown: false, doubleClicked: false, wasJustPressed: false, wasJustReleased: false };
       this.mouseButtonsDown[i] = false;
     }
 
@@ -355,7 +355,7 @@ export default class Input extends EventEmitter {
 
   private onMouseDblClick = (event: MouseEvent) => {
     event.preventDefault();
-    this.mouseButtons[event.button].dblClicked = true;
+    this.mouseButtons[event.button].doubleClicked = true;
   };
 
   private onContextMenu = (event: Event) => {

--- a/plugins/default/scene/editors/scene/engine.ts
+++ b/plugins/default/scene/editors/scene/engine.ts
@@ -177,13 +177,13 @@ function mouseUp() {
   setupSelectedNode();
   setupHelpers();
 
-  if(engine.gameInstance.input.mouseButtons[0].dblClicked){
+  if (engine.gameInstance.input.mouseButtons[0].doubleClicked) {
     focusActor(selectedNodeId);
-    engine.gameInstance.input.mouseButtons[0].dblClicked = false;
+    engine.gameInstance.input.mouseButtons[0].doubleClicked = false;
   }
 }
 
-function focusActor(selectedNodeId: string) {
+export function focusActor(selectedNodeId: string) {
   const position = new THREE.Box3().setFromObject(data.sceneUpdater.bySceneNodeId[selectedNodeId].actor.threeObject).center();
   if (ui.cameraMode === "2D") position.z = engine.cameraActor.getLocalPosition(new THREE.Vector3()).z;
   engine.cameraActor.setLocalPosition(position);

--- a/plugins/default/scene/editors/scene/engine.ts
+++ b/plugins/default/scene/editors/scene/engine.ts
@@ -176,6 +176,18 @@ function mouseUp() {
   }
   setupSelectedNode();
   setupHelpers();
+
+  if(engine.gameInstance.input.mouseButtons[0].dblClicked){
+    focusActor(selectedNodeId);
+    engine.gameInstance.input.mouseButtons[0].dblClicked = false;
+  }
+}
+
+function focusActor(selectedNodeId: string) {
+  const position = new THREE.Box3().setFromObject(data.sceneUpdater.bySceneNodeId[selectedNodeId].actor.threeObject).center();
+  if (ui.cameraMode === "2D") position.z = engine.cameraActor.getLocalPosition(new THREE.Vector3()).z;
+  engine.cameraActor.setLocalPosition(position);
+  if (ui.cameraMode === "3D") engine.cameraActor.moveOriented(new THREE.Vector3(0, 0, 20));
 }
 
 export function setupHelpers() {

--- a/plugins/default/scene/editors/scene/ui.ts
+++ b/plugins/default/scene/editors/scene/ui.ts
@@ -343,7 +343,16 @@ function onNodesTreeViewDrop(event: DragEvent, dropLocation: TreeView.DropLocati
   return false;
 }
 
-function onNodeActivate() { ui.nodesTreeView.selectedNodes[0].classList.toggle("collapsed"); }
+function onNodeActivate() {
+  // Focus an actor by double clicking on treeview
+  if (ui.nodesTreeView.selectedNodes.length !== 1) return;
+  const nodeId = ui.nodesTreeView.selectedNodes[0].dataset["id"];
+  const position = new THREE.Box3().setFromObject(data.sceneUpdater.bySceneNodeId[nodeId].actor.threeObject).center();
+  if (ui.cameraMode === "2D") position.z = engine.cameraActor.getLocalPosition(new THREE.Vector3()).z;
+  engine.cameraActor.setLocalPosition(position);
+  if (ui.cameraMode === "3D") engine.cameraActor.moveOriented(new THREE.Vector3(0, 0, 20));
+
+}
 
 export function setupSelectedNode() {
   setupHelpers();

--- a/plugins/default/scene/editors/scene/ui.ts
+++ b/plugins/default/scene/editors/scene/ui.ts
@@ -1,5 +1,5 @@
 import { data } from "./network";
-import engine, { setupHelpers, updateCameraMode } from "./engine";
+import engine, { setupHelpers, updateCameraMode, focusActor } from "./engine";
 
 import { Node } from "../../data/SceneNodes";
 import { Component } from "../../data/SceneComponents";
@@ -132,12 +132,8 @@ document.addEventListener("keydown", (event) => {
 
     case (window as any).KeyEvent.DOM_VK_F:
       if (ui.nodesTreeView.selectedNodes.length !== 1) return;
-
       const nodeId = ui.nodesTreeView.selectedNodes[0].dataset["id"];
-      const position = new THREE.Box3().setFromObject(data.sceneUpdater.bySceneNodeId[nodeId].actor.threeObject).center();
-      if (ui.cameraMode === "2D") position.z = engine.cameraActor.getLocalPosition(new THREE.Vector3()).z;
-      engine.cameraActor.setLocalPosition(position);
-      if (ui.cameraMode === "3D") engine.cameraActor.moveOriented(new THREE.Vector3(0, 0, 20));
+      focusActor(nodeId);
       break;
   }
 });
@@ -347,11 +343,7 @@ function onNodeActivate() {
   // Focus an actor by double clicking on treeview
   if (ui.nodesTreeView.selectedNodes.length !== 1) return;
   const nodeId = ui.nodesTreeView.selectedNodes[0].dataset["id"];
-  const position = new THREE.Box3().setFromObject(data.sceneUpdater.bySceneNodeId[nodeId].actor.threeObject).center();
-  if (ui.cameraMode === "2D") position.z = engine.cameraActor.getLocalPosition(new THREE.Vector3()).z;
-  engine.cameraActor.setLocalPosition(position);
-  if (ui.cameraMode === "3D") engine.cameraActor.moveOriented(new THREE.Vector3(0, 0, 20));
-
+  focusActor(nodeId);
 }
 
 export function setupSelectedNode() {


### PR DESCRIPTION
Allow focusing an actor by double-clicking:

1. on the tree view node(instead toggle collapse)
2. directly in viewport. 

Fix #12 