### PR TITLE
Don't check for collisions when body is not enabled

### DIFF
--- a/plugins/default/arcadePhysics2D/components/index.ts
+++ b/plugins/default/arcadePhysics2D/components/index.ts
@@ -127,6 +127,8 @@ namespace ArcadePhysics2D {
     body1.touches.right = false;
     body1.touches.left = false;
 
+    if (!body1.enabled) return false;
+
     let gotCollision = false;
     for (let body2 of bodies) {
       if (body2 === body1 || !body2.enabled) continue;


### PR DESCRIPTION
Currently, even if a body is disabled calling collides on it will check for collisions whilst lower down there's an explicit check for `body2` to be enabled. It would make sense for `body1` to not be taken into account if it's not enabled in the first place.