### PR TITLE
Exposed p2 classes: TopDownVehicle and WheelConstraint

### DIFF
--- a/plugins/extra/p2js/typescriptAPI/p2.d.ts.txt
+++ b/plugins/extra/p2js/typescriptAPI/p2.d.ts.txt
@@ -4,6 +4,40 @@
 
 declare module p2 {
 
+    export class TopDownVehicle {
+        constructor(chassiBody: Body, options?: {});
+        addToWorld(world: World): void;
+        removeFromWorld(): void;
+        addWheel(wheelOptions?: {
+            localForwardVector?: number[],
+            localPosition?: number[],
+            sideFriction?: number
+        }): WheelConstraint;
+        update(): void;
+
+        chassisBody: Body;
+        wheels: WheelConstraint[];
+    }
+
+    export class WheelConstraint extends Constraint {
+        constructor(vehicle: TopDownVehicle, options?: {
+            localForwardVector?: number[],
+            localPosition?: number[],
+            sideFriction?: number
+        });
+        setBrakeForce(number): void;
+        setSideFriction(number): void;
+        getSpeed(): number;
+        update(): void;
+
+        vehicle: TopDownVehicle;
+        steerValue: number;
+        engineForce: number;
+        localForwardVector: number[];
+        localPosition: number[];
+        
+    }
+
     export class AABB {
 
         constructor(options?: {


### PR DESCRIPTION
Not sure why, but these two classes were not exposed in the p2 module.

Relevant p2.js code: https://github.com/schteppe/p2.js/blob/v0.7.1/src/objects/TopDownVehicle.js