### PR TITLE
Replace >= and <= with > and < in ArcadePhysics2D.intersects()

### DIFF
--- a/plugins/default/arcadePhysics2D/components/index.ts
+++ b/plugins/default/arcadePhysics2D/components/index.ts
@@ -12,10 +12,10 @@ namespace ArcadePhysics2D {
   export function intersects(body1: ArcadeBody2D, body2: ArcadeBody2D) {
     if (body2.type === "tileMap") return checkTileMap(body1, body2, { moveBody: false });
 
-    if (body1.right() <= body2.left()) return false;
-    if (body1.left() >= body2.right()) return false;
-    if (body1.bottom() >= body2.top()) return false;
-    if (body1.top() <= body2.bottom()) return false;
+    if (body1.right() < body2.left()) return false;
+    if (body1.left() > body2.right()) return false;
+    if (body1.bottom() > body2.top()) return false;
+    if (body1.top() < body2.bottom()) return false;
     return true;
   }
 


### PR DESCRIPTION
If collides() is called, then the pair of bodies it was called with are
no longer considered intersecting, even though one would probably expect
a thing that is on top (e.g.) of another to qualify as 'colliding'. This
fixes that counterintuitive behavior.

First PR, please be gentle. In particular, apologies if I'm supposed to open an issue for tracking things like this. I'm really not sure.